### PR TITLE
Update chat.py with lowered temperature

### DIFF
--- a/starsim_ai/chat.py
+++ b/starsim_ai/chat.py
@@ -17,9 +17,9 @@ class LLMModels(Enum):
 
 class BaseQuery():
     def __init__(self, model='gpt-3.5-turbo', temperature=0.0, **kwargs):
-
-        if 'temperature' not in kwargs:
-            kwargs.update({'temperature':temperature})
+        # Update sampling temperature
+        kwargs.update({'temperature':temperature})
+        
         # Validate and parse the configuration
         self.config = LLMConfig(model=model)
 


### PR DESCRIPTION
Set default sampling temperature to 0 (instead of 0.7) (https://python.langchain.com/api_reference/openai/chat_models/langchain_openai.chat_models.base.ChatOpenAI.html#langchain_openai.chat_models.base.ChatOpenAI.temperature)