### PR TITLE
Enable filtering for non .py files 

### DIFF
--- a/aimigrate/files.py
+++ b/aimigrate/files.py
@@ -10,7 +10,7 @@ import sciris as sc
 import aimigrate as aim
 import subprocess
 
-def get_python_files(source_dir, gitignore=False):
+def get_python_files(source_dir, gitignore=False, filter=['.py']):
     """
     Recursively retrieves all Python files from the specified directory.
 
@@ -21,7 +21,7 @@ def get_python_files(source_dir, gitignore=False):
     Returns:
         list: A list of file paths to Python files found within the directory.
     """    
-    return get_repository_files(source_dir, gitignore=gitignore, filter=['.py'])
+    return get_repository_files(source_dir, gitignore=gitignore, filter=filter)
 
 def get_repository_files(source_dir, gitignore=False, filter=['.py']):
     """
@@ -92,7 +92,7 @@ class GitDiff(sc.prettyobj):
         if file is not None:
             return ''.join([''.join(diff['hunks']) for diff in self.diffs if diff["file"] == file])
         else:
-            return ''.join([''.join(diff['hunks']) for diff in self.diffs])
+            return ''.join(['\nFile:'+diff['file']+'\n:'+''.join(diff['hunks']) for diff in self.diffs])
 
 
     def count_all_tokens(self, model="gpt-4o"):

--- a/aimigrate/migrate_diff.py
+++ b/aimigrate/migrate_diff.py
@@ -32,7 +32,7 @@ class MigrateDiff(aim.CoreMigrate):
 
     def __init__(self, source_dir, dest_dir, files=None, # Input and output folders
                  library=None, library_alias=None, v_from=None, v_to=None,  # Migration settings
-                 include=None, exclude=None, diff_file=None, diff=None, patience=None, # Diff settings
+                 include=None, exclude=None, diff_file=None, diff=None, patience=None, filter=None, # Diff settings
                  model=None, model_kw=None, base_prompt=None, # Model settings
                  parallel=False, verbose=True, save=True, die=False, run=False): # Run settings
         # Inputs
@@ -51,6 +51,7 @@ class MigrateDiff(aim.CoreMigrate):
         self.model = model
         self.model_kw = sc.mergedicts(model_kw)
         self.base_prompt = sc.ifelse(base_prompt, default_base_prompt)
+        self.filter = sc.ifelse(filter, [".py"])
         self.parallel = parallel
         self.verbose = verbose
         self.save = save
@@ -76,7 +77,7 @@ class MigrateDiff(aim.CoreMigrate):
                 self.diff = f.readlines()
         else:
             self.parse_library()
-            library_files = aim.files.get_python_files(self.library, gitignore=True)
+            library_files = aim.files.get_python_files(self.library, gitignore=True, filter=self.filter)
             self.diff=''
             with aim.utils.TemporaryDirectoryChange(self.library):
                 for current_file in library_files:

--- a/aimigrate/migrate_oob.py
+++ b/aimigrate/migrate_oob.py
@@ -60,7 +60,7 @@ class MigrateOOB(aim.CoreMigrate):
                                                 'v_from': self.v_from,
                                                 'v_to': self.v_to},
                                                 encoder=self.encoder)
-
+    
     def run(self):
         # parse the files for migration
         self.make_code_files()

--- a/aimigrate/migrate_repo.py
+++ b/aimigrate/migrate_repo.py
@@ -34,7 +34,7 @@ Refactored code:
 class MigrateRepo(aim.CoreMigrate):
 
     def __init__(self, source_dir, dest_dir, files=None, # Input and output folders
-                 library=None, library_alias=None, v_from=None, v_to=None,  # Migration settings
+                 library=None, library_alias=None, v_from=None, v_to=None,  filter=None,# Migration settings
                  include=None, exclude=None, diff_file=None, diff=None, patience=None, # Diff settings
                  model=None, model_kw=None, base_prompt=None, # Model settings
                  parallel=False, verbose=True, save=True, die=False, run=False): # Run settings
@@ -54,6 +54,7 @@ class MigrateRepo(aim.CoreMigrate):
         self.model = model
         self.model_kw = sc.mergedicts(model_kw)
         self.base_prompt = sc.ifelse(base_prompt, default_base_prompt)
+        self.filter = sc.ifelse(filter, [".py"])
         self.parallel = parallel
         self.verbose = verbose
         self.save = save
@@ -98,7 +99,7 @@ class MigrateRepo(aim.CoreMigrate):
         self.log("Getting the repository files")
         self.parse_library()
         self.repo_files = []
-        all_repo_files = aim.files.get_python_files(self.library, gitignore=True)
+        all_repo_files = aim.files.get_python_files(self.library, gitignore=True, filter=self.filter)
         for current_file in all_repo_files:
             if self.include and not any(fnmatch.fnmatch(current_file, pattern) for pattern in self.include):
                 continue


### PR DESCRIPTION
This PR should match the submitted version (code associated with the 3 case studies). This allows you to filter for e.g. .ipynb or .md files along with .py files.